### PR TITLE
Harden CI deploy and upstream sync

### DIFF
--- a/.github/actions/deploy-over-ssh/action.yml
+++ b/.github/actions/deploy-over-ssh/action.yml
@@ -13,6 +13,12 @@ inputs:
   registry:
     description: Container registry host.
     required: true
+  registry_username:
+    description: Container registry username for the remote Docker host.
+    required: true
+  registry_password:
+    description: Container registry password for the remote Docker host.
+    required: true
   registry_repo:
     description: Container registry repository or namespace.
     required: true
@@ -28,8 +34,12 @@ inputs:
   base_path:
     description: Base path where compose should run.
     required: true
+  compose_service_name:
+    description: Docker Compose service name to restart.
+    required: false
+    default: ""
   container_name:
-    description: Optional container name override.
+    description: Optional container name override used for logs and compatibility.
     required: false
     default: ""
   image_name:
@@ -44,31 +54,39 @@ inputs:
     description: Whether to reload nginx after deploy.
     required: false
     default: "true"
+  nginx_container:
+    description: Nginx container name to reload.
+    required: false
+    default: "nginx"
 runs:
   using: composite
   steps:
     - name: Deploy service
-      uses: appleboy/ssh-action@v1.2.2
+      uses: appleboy/ssh-action@v1.2.5
       env:
         CI_REGISTRY: ${{ inputs.registry }}
+        CI_REGISTRY_USER: ${{ inputs.registry_username }}
+        CI_REGISTRY_PASSWORD: ${{ inputs.registry_password }}
         CI_REGISTRY_REPO: ${{ inputs.registry_repo }}
         SERVICE_NAME: ${{ inputs.service_name }}
         SERVICE_TAG: ${{ inputs.service_tag }}
         DOCKER_COMPOSE_FILE: ${{ inputs.docker_compose_file }}
         BASE_PATH: ${{ inputs.base_path }}
+        COMPOSE_SERVICE_NAME_OVERRIDE: ${{ inputs.compose_service_name }}
         CONTAINER_NAME_OVERRIDE: ${{ inputs.container_name }}
         IMAGE_NAME_OVERRIDE: ${{ inputs.image_name }}
         POST_DEPLOY_SLEEP_SECONDS: ${{ inputs.post_deploy_sleep_seconds }}
         RELOAD_NGINX: ${{ inputs.reload_nginx }}
+        NGINX_CONTAINER: ${{ inputs.nginx_container }}
       with:
         host: ${{ inputs.host }}
         username: ${{ inputs.username }}
         key: ${{ inputs.ssh_private_key }}
-        envs: CI_REGISTRY,CI_REGISTRY_REPO,SERVICE_NAME,SERVICE_TAG,DOCKER_COMPOSE_FILE,BASE_PATH,CONTAINER_NAME_OVERRIDE,IMAGE_NAME_OVERRIDE,POST_DEPLOY_SLEEP_SECONDS,RELOAD_NGINX
+        envs: CI_REGISTRY,CI_REGISTRY_USER,CI_REGISTRY_PASSWORD,CI_REGISTRY_REPO,SERVICE_NAME,SERVICE_TAG,DOCKER_COMPOSE_FILE,BASE_PATH,COMPOSE_SERVICE_NAME_OVERRIDE,CONTAINER_NAME_OVERRIDE,IMAGE_NAME_OVERRIDE,POST_DEPLOY_SLEEP_SECONDS,RELOAD_NGINX,NGINX_CONTAINER
         script: |
           set -euo pipefail
 
-          for var in CI_REGISTRY CI_REGISTRY_REPO SERVICE_NAME SERVICE_TAG DOCKER_COMPOSE_FILE BASE_PATH; do
+          for var in CI_REGISTRY CI_REGISTRY_USER CI_REGISTRY_PASSWORD CI_REGISTRY_REPO SERVICE_NAME SERVICE_TAG DOCKER_COMPOSE_FILE BASE_PATH; do
             if [ -z "${!var}" ]; then
               echo "Error: Environment variable ${var} is not set."
               exit 1
@@ -80,9 +98,14 @@ runs:
             IMAGE_NAME="${SERVICE_NAME}"
           fi
 
+          COMPOSE_SERVICE="${COMPOSE_SERVICE_NAME_OVERRIDE}"
+          if [ -z "${COMPOSE_SERVICE}" ]; then
+            COMPOSE_SERVICE="${SERVICE_NAME}"
+          fi
+
           CONTAINER="${CONTAINER_NAME_OVERRIDE}"
           if [ -z "${CONTAINER}" ]; then
-            CONTAINER="${SERVICE_NAME}"
+            CONTAINER="${COMPOSE_SERVICE}"
           fi
 
           IMAGE="${CI_REGISTRY}/${CI_REGISTRY_REPO}/${IMAGE_NAME}:${SERVICE_TAG}"
@@ -94,14 +117,99 @@ runs:
             exit 1
           fi
 
-          sed -i -E "s|^([[:space:]]*image:[[:space:]]*).*$|\1${IMAGE}|g" "${DOCKER_COMPOSE_FILE}"
+          if ! command -v python3 >/dev/null 2>&1; then
+            echo "python3 is required on the deploy host to update ${DOCKER_COMPOSE_FILE} safely."
+            exit 1
+          fi
 
-          docker compose -f "${DOCKER_COMPOSE_FILE}" up -d --force-recreate "${CONTAINER}"
+          python3 - "${DOCKER_COMPOSE_FILE}" "${COMPOSE_SERVICE}" "${IMAGE}" <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          compose_path = Path(sys.argv[1])
+          target_service = sys.argv[2]
+          image = sys.argv[3]
+
+          lines = compose_path.read_text(encoding="utf-8").splitlines()
+          output = []
+          in_services = False
+          services_indent = None
+          in_target = False
+          target_indent = None
+          found_target = False
+          updated_image = False
+
+          def indent_of(line):
+              return len(line) - len(line.lstrip(" "))
+
+          def append_image_if_needed():
+              global updated_image
+              if in_target and not updated_image:
+                  output.append(" " * (target_indent + 2) + f"image: {image}")
+                  updated_image = True
+
+          for line in lines:
+              stripped = line.strip()
+              is_content = bool(stripped) and not stripped.startswith("#")
+              indent = indent_of(line)
+
+              if in_target and is_content and indent <= target_indent:
+                  append_image_if_needed()
+                  in_target = False
+
+              if is_content and stripped == "services:":
+                  in_services = True
+                  services_indent = indent
+                  output.append(line)
+                  continue
+
+              if in_services and is_content and indent <= services_indent and stripped != "services:":
+                  in_services = False
+
+              if in_services and is_content and indent > services_indent:
+                  match = re.match(r"^\\s*([A-Za-z0-9_.-]+):\\s*(?:#.*)?$", line)
+                  if match and indent == services_indent + 2:
+                      if match.group(1) == target_service:
+                          in_target = True
+                          target_indent = indent
+                          found_target = True
+                          updated_image = False
+                      elif in_target:
+                          append_image_if_needed()
+                          in_target = False
+
+              if in_target and is_content and indent > target_indent and stripped.startswith("image:"):
+                  output.append(" " * indent + f"image: {image}")
+                  updated_image = True
+                  continue
+
+              output.append(line)
+
+          if in_target:
+              append_image_if_needed()
+
+          if not found_target:
+              raise SystemExit(f"Compose service not found: {target_service}")
+
+          compose_path.write_text("\\n".join(output) + "\\n", encoding="utf-8")
+          PY
+
+          printf '%s' "${CI_REGISTRY_PASSWORD}" | docker login "${CI_REGISTRY}" --username "${CI_REGISTRY_USER}" --password-stdin
+
+          docker compose -f "${DOCKER_COMPOSE_FILE}" pull "${COMPOSE_SERVICE}"
+          docker compose -f "${DOCKER_COMPOSE_FILE}" up -d --force-recreate "${COMPOSE_SERVICE}"
 
           if [ -n "${POST_DEPLOY_SLEEP_SECONDS}" ]; then
             sleep "${POST_DEPLOY_SLEEP_SECONDS}"
           fi
 
+          docker compose -f "${DOCKER_COMPOSE_FILE}" ps "${COMPOSE_SERVICE}" || true
+
           if [ "${RELOAD_NGINX}" = "true" ]; then
-            docker exec nginx nginx -s reload || true
+            if docker ps --format '{{.Names}}' | grep -Fxq "${NGINX_CONTAINER}"; then
+              docker exec "${NGINX_CONTAINER}" nginx -s reload || true
+            else
+              echo "Nginx container '${NGINX_CONTAINER}' not found, skipping reload."
+            fi
           fi

--- a/.github/ci-cd.md
+++ b/.github/ci-cd.md
@@ -1,0 +1,74 @@
+# CI/CD and Upstream Sync
+
+This fork deploys the `atleta` branch as the Atleta-hosted Polkadot JS Apps
+image. The upstream source is `polkadot-js/apps`, branch `master`.
+
+## Remotes
+
+Local clones should keep both remotes:
+
+```bash
+git remote add upstream git@github.com:polkadot-js/apps.git
+git fetch --all --prune --tags
+```
+
+Use `atleta` for Atleta-specific changes. Use the `Sync upstream` workflow to
+merge `polkadot-js/apps:master` into a PR branch targeting `atleta`.
+
+## Workflows
+
+- `CI config validation` validates workflow/action YAML and Docker Compose on
+  PRs and pushes to `atleta`.
+- `Build and release Docker image` builds and pushes the Docker image.
+- `Deploy service` deploys an already-built image over SSH.
+- `Sync upstream` creates or updates a PR from
+  `devops/sync-upstream-master` into `atleta`.
+
+Production deployment is manual-only through `Deploy service` with
+`confirm_prod=DEPLOY_PROD`.
+
+## Repository Variables
+
+Required repository variables:
+
+```text
+SERVICE_NAME=sportchain-explorer
+DOCKER_COMPOSE_FILE=docker-compose.yml
+```
+
+Optional repository variables:
+
+```text
+COMPOSE_SERVICE_NAME=sportchain-explorer
+CONTAINER_NAME=sportchain-explorer
+AUTO_DEPLOY_DEV=false
+```
+
+Set `AUTO_DEPLOY_DEV=true` only after the `dev` environment has SSH deploy
+secrets. Manual dev deployment can also be triggered by running
+`Build and release Docker image` with `deploy_after_build=true`.
+
+## Repository Secrets
+
+Required repository secrets:
+
+```text
+CI_REGISTRY
+CI_REGISTRY_REPO
+CI_REGISTRY_USER
+CI_REGISTRY_PASSWORD
+```
+
+## Environment Secrets
+
+Each deployable GitHub environment (`dev`, `prod`) needs:
+
+```text
+BASE_PATH
+HOST_1
+HOST_1_USERNAME
+SSH_PRIVATE_KEY
+```
+
+The current `prod` environment has these deploy secrets. The `dev` environment
+must receive its own values before automatic dev rollout can succeed.

--- a/.github/workflows/build_and_release_image.yml
+++ b/.github/workflows/build_and_release_image.yml
@@ -23,6 +23,11 @@ on:
         description: "Commit SHA for build/deploy (default: event SHA)"
         required: false
         default: ""
+      deploy_after_build:
+        description: "Trigger deploy after build (dev only; prod remains manual-only)"
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - atleta
@@ -43,6 +48,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_REF: ${{ github.ref }}
+          AUTO_DEPLOY_DEV: ${{ vars.AUTO_DEPLOY_DEV || 'false' }}
+          INPUT_DEPLOY_AFTER_BUILD: ${{ github.event.inputs.deploy_after_build || 'false' }}
         run: |
           set -euo pipefail
 
@@ -99,9 +106,22 @@ jobs:
 
           TRIGGER_DEPLOY="false"
           DEPLOY_EVENT=""
-          if [ "${EVENT_NAME}" = "push" ] && [ "${TARGET_ENV}" = "dev" ]; then
-            TRIGGER_DEPLOY="true"
-            DEPLOY_EVENT="Deploy"
+          if [ "${TARGET_ENV}" = "dev" ]; then
+            if [ "${EVENT_NAME}" = "push" ] && [ "${AUTO_DEPLOY_DEV}" = "true" ]; then
+              TRIGGER_DEPLOY="true"
+              DEPLOY_EVENT="Deploy"
+            elif [ "${EVENT_NAME}" = "workflow_dispatch" ] && [ "${INPUT_DEPLOY_AFTER_BUILD}" = "true" ]; then
+              TRIGGER_DEPLOY="true"
+              DEPLOY_EVENT="Deploy"
+            fi
+          fi
+
+          if [ "${EVENT_NAME}" = "push" ] && [ "${TARGET_ENV}" = "dev" ] && [ "${AUTO_DEPLOY_DEV}" != "true" ]; then
+            echo "Dev auto-deploy is disabled. Set AUTO_DEPLOY_DEV=true to enable it."
+          fi
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ] && [ "${TARGET_ENV}" = "prod" ] && [ "${INPUT_DEPLOY_AFTER_BUILD}" = "true" ]; then
+            echo "Prod deploy is manual-only via Deploy service workflow."
           fi
 
           MATRIX="[{\"service_id\":\"${SERVICE_ID}\",\"environment\":\"${TARGET_ENV}\",\"source_ref\":\"${SOURCE_REF}\",\"build_context\":\"./\",\"dockerfile\":\"docker/Dockerfile\",\"deploy_event\":\"${DEPLOY_EVENT}\",\"trigger_deploy\":${TRIGGER_DEPLOY}}]"
@@ -122,7 +142,7 @@ jobs:
 
     steps:
       - name: Checkout repository for local actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ matrix.source_ref }}
 
@@ -154,22 +174,22 @@ jobs:
           echo "DOCKERFILE=${{ matrix.dockerfile }}" >> "$GITHUB_ENV"
 
       - name: Checkout repository at selected commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.SERVICE_TAG }}
 
       - name: Build Docker image
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.CI_REGISTRY }}
           username: ${{ secrets.CI_REGISTRY_USER }}
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}
 
       - name: Build and release Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.CONTEXT }}
           file: ${{ env.DOCKERFILE }}
@@ -190,7 +210,7 @@ jobs:
 
       - name: Trigger Deploy Workflow
         if: matrix.trigger_deploy && matrix.deploy_event != ''
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI config validation
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+    branches:
+      - atleta
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate workflow YAML
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' \
+            .github/workflows/*.yml \
+            .github/actions/*/action.yml
+
+      - name: Validate Docker Compose
+        shell: bash
+        run: docker compose -f docker/docker-compose.yml config

--- a/.github/workflows/deploy_service.yml
+++ b/.github/workflows/deploy_service.yml
@@ -124,7 +124,7 @@ jobs:
 
     steps:
       - name: Checkout repository for local actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate explicit prod confirmation
         if: github.event_name == 'workflow_dispatch' && needs.prepare.outputs.environment == 'prod'
@@ -152,18 +152,30 @@ jobs:
         env:
           DOCKER_COMPOSE_FILE: ${{ vars.DOCKER_COMPOSE_FILE }}
           BASE_PATH: ${{ secrets.BASE_PATH }}
+          HOST_1: ${{ secrets.HOST_1 }}
+          HOST_1_USERNAME: ${{ secrets.HOST_1_USERNAME }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          CI_REGISTRY: ${{ secrets.CI_REGISTRY }}
+          CI_REGISTRY_REPO: ${{ secrets.CI_REGISTRY_REPO }}
+          CI_REGISTRY_USER: ${{ secrets.CI_REGISTRY_USER }}
+          CI_REGISTRY_PASSWORD: ${{ secrets.CI_REGISTRY_PASSWORD }}
         run: |
           set -euo pipefail
 
           SERVICE_NAME="${{ vars.SERVICE_NAME }}"
+          COMPOSE_SERVICE_NAME="${{ vars.COMPOSE_SERVICE_NAME }}"
           CONTAINER_NAME="${{ vars.CONTAINER_NAME }}"
 
           if [ -z "${SERVICE_NAME}" ]; then
             SERVICE_NAME="sportchain-explorer"
           fi
 
+          if [ -z "${COMPOSE_SERVICE_NAME}" ]; then
+            COMPOSE_SERVICE_NAME="${SERVICE_NAME}"
+          fi
+
           if [ -z "${CONTAINER_NAME}" ]; then
-            CONTAINER_NAME="${SERVICE_NAME}"
+            CONTAINER_NAME="${COMPOSE_SERVICE_NAME}"
           fi
 
           if [ -z "${DOCKER_COMPOSE_FILE}" ]; then
@@ -176,19 +188,27 @@ jobs:
             exit 1
           fi
 
+          for secret_name in HOST_1 HOST_1_USERNAME SSH_PRIVATE_KEY CI_REGISTRY CI_REGISTRY_REPO CI_REGISTRY_USER CI_REGISTRY_PASSWORD; do
+            if [ -z "${!secret_name}" ]; then
+              echo "${secret_name} is required in GitHub Secrets."
+              exit 1
+            fi
+          done
+
           echo "EFFECTIVE_SERVICE_NAME=${SERVICE_NAME}" >> "$GITHUB_ENV"
+          echo "EFFECTIVE_COMPOSE_SERVICE_NAME=${COMPOSE_SERVICE_NAME}" >> "$GITHUB_ENV"
           echo "EFFECTIVE_CONTAINER_NAME=${CONTAINER_NAME}" >> "$GITHUB_ENV"
           echo "EFFECTIVE_BASE_PATH=${BASE_PATH}" >> "$GITHUB_ENV"
           echo "EFFECTIVE_DOCKER_COMPOSE_FILE=${DOCKER_COMPOSE_FILE}" >> "$GITHUB_ENV"
           echo "IMAGE_NAME=${SERVICE_NAME}" >> "$GITHUB_ENV"
 
       - name: Checkout repository at selected commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.ref || env.SERVICE_TAG }}
 
       - name: Log in to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.CI_REGISTRY }}
           username: ${{ secrets.CI_REGISTRY_USER }}
@@ -210,11 +230,14 @@ jobs:
           username: ${{ secrets.HOST_1_USERNAME }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
           registry: ${{ secrets.CI_REGISTRY }}
+          registry_username: ${{ secrets.CI_REGISTRY_USER }}
+          registry_password: ${{ secrets.CI_REGISTRY_PASSWORD }}
           registry_repo: ${{ secrets.CI_REGISTRY_REPO }}
           service_name: ${{ env.EFFECTIVE_SERVICE_NAME }}
           service_tag: ${{ env.SERVICE_TAG }}
           docker_compose_file: ${{ env.EFFECTIVE_DOCKER_COMPOSE_FILE }}
           base_path: ${{ env.EFFECTIVE_BASE_PATH }}
+          compose_service_name: ${{ env.EFFECTIVE_COMPOSE_SERVICE_NAME }}
           container_name: ${{ env.EFFECTIVE_CONTAINER_NAME }}
           image_name: ${{ env.IMAGE_NAME }}
           post_deploy_sleep_seconds: "10"

--- a/.github/workflows/sync_upstream.yml
+++ b/.github/workflows/sync_upstream.yml
@@ -1,0 +1,115 @@
+name: Sync upstream
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      upstream_branch:
+        description: "Upstream branch to merge from polkadot-js/apps"
+        required: false
+        default: "master"
+      target_branch:
+        description: "Fork branch to merge into"
+        required: false
+        default: "atleta"
+      sync_branch:
+        description: "Branch used for the sync PR"
+        required: false
+        default: "devops/sync-upstream-master"
+
+concurrency:
+  group: sync-upstream-${{ github.event.inputs.target_branch || 'atleta' }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      UPSTREAM_REPO: polkadot-js/apps
+      UPSTREAM_BRANCH: ${{ github.event.inputs.upstream_branch || 'master' }}
+      TARGET_BRANCH: ${{ github.event.inputs.target_branch || 'atleta' }}
+      SYNC_BRANCH: ${{ github.event.inputs.sync_branch || 'devops/sync-upstream-master' }}
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
+          fetch-depth: 0
+
+      - name: Merge upstream into sync branch
+        id: merge
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
+          git fetch origin "${TARGET_BRANCH}"
+          git fetch upstream "${UPSTREAM_BRANCH}"
+
+          git checkout -B "${SYNC_BRANCH}" "origin/${TARGET_BRANCH}"
+          before="$(git rev-parse HEAD)"
+          upstream_head="$(git rev-parse "upstream/${UPSTREAM_BRANCH}")"
+
+          if ! git merge --no-edit --no-ff "upstream/${UPSTREAM_BRANCH}"; then
+            echo "Upstream merge has conflicts. Resolve them locally and push ${SYNC_BRANCH}."
+            git diff --name-only --diff-filter=U
+            exit 1
+          fi
+
+          after="$(git rev-parse HEAD)"
+          echo "upstream_head=${upstream_head}" >> "$GITHUB_OUTPUT"
+
+          if [ "${before}" = "${after}" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No upstream changes to sync."
+            exit 0
+          fi
+
+          git push origin "HEAD:${SYNC_BRANCH}" --force-with-lease
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update sync PR
+        if: steps.merge.outputs.has_changes == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          body="$(mktemp)"
+          cat > "${body}" <<EOF
+          ## Summary
+          - Syncs \`${TARGET_BRANCH}\` with \`${UPSTREAM_REPO}:${UPSTREAM_BRANCH}\`.
+          - Preserves Atleta-specific RPC/configuration, Docker, and CI/CD changes through a normal merge branch.
+
+          ## Upstream
+          - Repository: \`${UPSTREAM_REPO}\`
+          - Branch: \`${UPSTREAM_BRANCH}\`
+          - Head: \`${{ steps.merge.outputs.upstream_head }}\`
+
+          ## Validation
+          - Review conflicts or generated lockfile changes before merging.
+          - Run the regular build workflow before rollout when application files changed.
+          EOF
+
+          pr_number="$(gh pr list --repo "${GITHUB_REPOSITORY}" --head "${SYNC_BRANCH}" --base "${TARGET_BRANCH}" --state open --json number --jq '.[0].number // ""')"
+          if [ -n "${pr_number}" ]; then
+            gh pr edit "${pr_number}" --repo "${GITHUB_REPOSITORY}" --body-file "${body}"
+          else
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --head "${SYNC_BRANCH}" \
+              --base "${TARGET_BRANCH}" \
+              --title "Sync upstream ${UPSTREAM_REPO}:${UPSTREAM_BRANCH}" \
+              --body-file "${body}"
+          fi

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -17,8 +17,8 @@ IMAGE_VERSION=$(cat package.json \
   | sed 's/[",]//g' \
   | sed 's/ //g')
 
-echo "*** Building $NAME"
-docker compose -f docker/docker-compose.yaml build 
+echo "*** Building $IMAGE_NAME"
+docker compose -f docker/docker-compose.yml build
 
 docker login -u $IMAGE_REPO -p $DOCKER_PASS
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,10 @@
-version: "3"
-
 services:
   sportchain-explorer:
     image: sportchain-explorer
     container_name: sportchain-explorer
     restart: unless-stopped
+    environment:
+      WS_URL: ${WS_URL:-}
     expose:
       - "80"
     networks:


### PR DESCRIPTION
## Summary
- Adds a lightweight CI config validation workflow for PRs and pushes to `atleta`.
- Adds a first-class `Sync upstream` workflow that merges `polkadot-js/apps:master` into a PR branch targeting `atleta`.
- Updates CI actions to current major versions: `actions/checkout@v6`, Docker actions `@v4/@v7`, `peter-evans/repository-dispatch@v4`, and `appleboy/ssh-action@v1.2.5`.
- Hardens SSH deploy by logging into the Docker registry on the remote host before pulling the image.
- Replaces global compose `sed` image replacement with scoped service-level image update, so multi-service compose files are not accidentally rewritten.
- Splits Docker image name, compose service name, and container name so deploy can target Docker Compose correctly.
- Makes dev auto-deploy opt-in through `AUTO_DEPLOY_DEV=true`; prod remains manual-only with `confirm_prod=DEPLOY_PROD`.
- Documents required repo variables, repo secrets, environment secrets, and upstream sync flow in `.github/ci-cd.md`.
- Fixes local Docker helpers: removes obsolete compose `version`, exposes `WS_URL`, and fixes `docker/build.sh` to use `docker-compose.yml` and `IMAGE_NAME`.

## Problem
The fork already had build/deploy workflows, but there were a few operational gaps:
- Push builds attempted automatic dev rollout even though the `dev` GitHub environment has no SSH deploy secrets, which caused repository_dispatch deploy failures.
- The deploy action changed every `image:` line in the remote compose file, which is unsafe once the compose file has more than one service.
- The runner logged in to the registry, but the remote Docker host did not, so private registry pulls depended on prior manual state.
- Docker Compose service name and container name were treated as the same value.
- Upstream sync existed only in old/stale branches and targeted `test-auto-pr`; this PR adds a maintained workflow that targets `atleta`.

## GitHub Settings Updated
Non-secret variables were added/confirmed:
- repo `COMPOSE_SERVICE_NAME=sportchain-explorer`
- repo `AUTO_DEPLOY_DEV=false`
- env `dev` `DOCKER_COMPOSE_FILE=docker-compose.yml`
- env `prod` `DOCKER_COMPOSE_FILE=docker-compose.yml`

Current secret state checked with `gh`:
- repo registry secrets exist: `CI_REGISTRY`, `CI_REGISTRY_REPO`, `CI_REGISTRY_USER`, `CI_REGISTRY_PASSWORD`
- `prod` deploy secrets exist: `BASE_PATH`, `HOST_1`, `HOST_1_USERNAME`, `SSH_PRIVATE_KEY`
- `dev` deploy secrets are missing; keep `AUTO_DEPLOY_DEV=false` until dev has its own deploy values

## Upstream State
- Fork default branch: `atleta`
- Upstream remote: `polkadot-js/apps`, branch `master`
- Current comparison after fetch: `atleta` is behind upstream by 48 commits and ahead by 38 Atleta-specific commits
- This PR does not merge upstream application changes; it adds the workflow to create a normal sync PR into `atleta`

## Verification
- `git fetch --all --prune --tags`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' .github/workflows/*.yml .github/actions/*/action.yml`
- `docker compose -f docker/docker-compose.yml config`
- scoped compose image updater tested against `docker/docker-compose.yml`
- `git diff --check`


## Upstream Dry Run
A local dry-run merge of `upstream/master` into `origin/atleta` currently has conflicts in:
- `packages/apps-config/src/endpoints/testing.ts`
- `packages/apps-config/src/settings/ethereumChains.ts`
- `yarn.lock`

So this PR intentionally does not merge upstream application changes. The new `Sync upstream` workflow will surface these conflicts in a dedicated sync PR/run instead of mixing them with CI/CD hardening.
